### PR TITLE
change Imports so that they work with Python3.6

### DIFF
--- a/lda2vec/Lda2vec.py
+++ b/lda2vec/Lda2vec.py
@@ -1,5 +1,8 @@
-import tensorflow as tf, numpy as np, lda2vec.word_embedding as W, lda2vec.embedding_mixture as M, \
-    lda2vec.dirichlet_likelihood as DL
+import tensorflow as tf
+import numpy as np
+import lda2vec.word_embedding as W
+import lda2vec.embedding_mixture as M
+import lda2vec.dirichlet_likelihood as DL
 from datetime import datetime
 
 


### PR DESCRIPTION
I couldn't get the imports to work for python3.6 unless I changed the imports to be like this.